### PR TITLE
Add LWP::Protocol::https PREREQ_PM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /Makefile
 /blib/
 /pm_to_blib
+.idea/

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -16,6 +16,7 @@ WriteMakefile(
 		'MooX::Options'                  => 0,
 		'autodie'                        => 0,
 		'LWP::UserAgent'                 => 0,
+		'LWP::Protocol::https'           => 0,
 		'POSIX'                          => 0,
 		'YAML'                           => 0,
 		'Time::HiRes'                    => 0,


### PR DESCRIPTION
If you try to use this on TLS / SSL (https) based sites, you might get
HTTP 501 or some other error.
LWP::UserAgent itself doesnt handle https sites.

Also, added .idea/ folder to gitignore for those who use IntelliJ IDEs
(I use PyCharm for instance for Perl as well)
